### PR TITLE
Fix reducer in configStore

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,8 +1,19 @@
 import { configureStore } from "@reduxjs/toolkit";
-import userSlice from "slice/userSlice";
+import messengerPreviewReducer from "slice/messengerPreviewSlice";
+import userReducer from "slice/userSlice";
 
 const store = configureStore({
-  reducer: userSlice,
+  reducer:{
+    user: userReducer,
+    messengerPreview: messengerPreviewReducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        // Ignore these field paths in all actions
+        ignoredActionPaths: ["meta.arg", "payload.timestamp"],
+      },
+    }),
 });
 
 export default store;

--- a/src/slice/messengerPreviewSlice.js
+++ b/src/slice/messengerPreviewSlice.js
@@ -1,0 +1,21 @@
+import {createSlice} from '@reduxjs/toolkit'
+
+const initialState = {
+  messengerPreview: null
+};
+
+const messengerPreviewSlice = createSlice({
+  name: 'messengerPreview',
+  initialState,
+  reducers: {
+    setMessengerPreview: (state, action) => {
+      state.messengerPreview = action.payload;
+    },
+  }
+});
+
+export const {setMessengerPreview} = messengerPreviewSlice.actions;
+
+export default messengerPreviewSlice.reducer;
+
+export const selectorMessengerPreview = state => state.messengerPreview.messengerPreview;

--- a/src/slice/userSlice.js
+++ b/src/slice/userSlice.js
@@ -18,6 +18,7 @@ const userSlice = createSlice({
 });
 
 export const {setUserInformation, clearUserInformation} = userSlice.actions;
+
 export default userSlice.reducer;
 
-export const selectorUser = state => state.user;
+export const selectorUser = state => state.user.user;


### PR DESCRIPTION
## Redux-toolkit

### Error: cannot dispatch action
`userSlice.js`
```jsx
export const selectorUser = state => state.user;
```
`store.js`
```jsx
reducer: userSlice,
```
=> default state at userSlice

**So,** when add new reducer to `store.js`:
```jsx
reducer:{
    userReducer,
    messengerPreviewReducer,
  },
```
**ERROR: DISPATCH NOT ACTIVE**

### Fix
1. Set key - value for reducer item in `store.js`:
```jsx
reducer:{
    user: userReducer,
    messengerPreview: messengerPreviewReducer,
  },
```
2. Access state of each reducer by key, example: 
```jsx
export const selectorUser = state => state.user.user;
```